### PR TITLE
fix date to show current day shows

### DIFF
--- a/server/dateConverter.js
+++ b/server/dateConverter.js
@@ -28,7 +28,7 @@ module.exports = function(data) {
     .map((x, i) => {
       return { ...x, endTimeConverted: convertedDates[i] }
     })
-    .filter(show => show.endTimeConverted >= new Date())
-
+    .filter(show => Date.parse(show.endTimeConverted) >= Date.now() - 86400000)
+  console.log(convertedData)
   return convertedData
 }


### PR DESCRIPTION
Fixes #1 

The show.endTimeConverted does not include a time, so it was defaulting to the first minute of the day. This was causing all shows for that day to be considered done on the first second of that particular day. To fix this I changed the comparison to be relative to yesterday at the current time. This is not a perfect fix because it will not actually stop showing shows once they are over, but rather once the day changes. It works for now though.