### PR TITLE
fix parsing after website update

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -10,11 +10,11 @@ const app = express()
 let data
 let objData
 let newData
-const re = /{"eventId":.*}/gi
+const re = /eventId".*?"endTime".*?}/g
 
 const getData = async callback => {
   try {
-    data = await axios.get('https://phillyimprovtheater.com/shows/month')
+    data = await axios.get('https://phillyimprovtheater.com/shows/')
     data = data.data.replace(/&quot;/g, '"')
     data = data.replace(/&#039;/g, "'")
     data = data.replace(/&#8217;/g, "'")
@@ -23,20 +23,33 @@ const getData = async callback => {
     data = data.replace(/&#8220;/g, '-')
     data = data.replace(/&#8211;/g, '-')
     data = data.replace(/&#8221;/g, '-')
-    data = data.replace(
-      /"i18n":{"find_out_more":"Find out more \\u00bb","for_date":"Events for"},/g,
-      ''
-    )
+    // data = data.replace(
+    //   /"i18n":{"find_out_more":"Find out more \\u00bb","for_date":"Events for"},/g,
+    //   ''
+    // )
+    // data = data.match(re)
+    // objData = data.map((x, i) => {
+    //   x = JSON.parse(x)
+    //   return x
+    // })
+    // newData = dateConverter(objData)
+    // callback()
+    // } catch (error) {
+    // console.error(error)
+    // }
+    // ^^ for posterity
     data = data.match(re)
-    objData = data.map((x, i) => {
+    data = data.map(x => {
+      return `{"${x}`
+    })
+    objData = data.map(x => {
       x = JSON.parse(x)
       return x
     })
-    newData = dateConverter(objData)
-    callback()
-  } catch (error) {
-    console.error(error)
+  } catch (err) {
+    console.log(err)
   }
+  callback()
 }
 
 getData(() => console.log('Initial data pulled'))
@@ -48,6 +61,6 @@ const job = new CronJob('0 */6 * * *', () => {
 job.start()
 
 app.get('/', (req, res) => res.send('Welcome to the improved calendar'))
-app.get('/data', (req, res) => res.send(newData))
+app.get('/data', (req, res) => res.send(objData))
 
 app.listen(4000, () => console.log('Listening on port 4000'))


### PR DESCRIPTION
There was some kind of update to the code on the website that broke the admittedly frail parsing. Stuff like this:

```
    data = data.data.replace(/&quot;/g, '"')
    data = data.replace(/&#039;/g, "'")
    data = data.replace(/&#8217;/g, "'")
    data = data.replace(/&l.....gt;/gi, '...')
    data = data.replace(/&#038;/g, '&')
    data = data.replace(/&#8220;/g, '-')
    data = data.replace(/&#8211;/g, '-')
    data = data.replace(/&#8221;/g, '-')
```
(why didn't I chain those together btw? I'll clean this code up at some point)

and
```
    data = data.map(x => {
      return `{"${x}`
    })

}
```

I just didn't want to use something like [cheerio](https://github.com/cheeriojs/cheerio) because it feels like overkill.

This update gets the site back up and running. I still need to update the data parsing that allowed the site to hide past events. 