### PR TITLE
Filter out past dates

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -35,7 +35,14 @@ class App extends Component {
     } else if (!isLoaded) {
       return <h1>Loading... uhm... yeah...</h1>
     } else {
-      return data.map(
+      return data
+        .filter(({eventId}) => {
+          const eventDate = new Date(eventId.slice(-10))
+          const yesterday = new Date()
+          yesterday.setTime(yesterday.getTime() - (24*60*60*1000))
+          return eventDate >= yesterday
+        }) 
+        .map(
         ({ title, dateDisplay, excerpt, permalink, imageSrc }) => {
           return (
             <Card


### PR DESCRIPTION
This is done on the client side. It creates a date object from the `eventId` which always has the date as the last 10 digits. It then generically compares that to right now minus 24 hours. This is so that tonight's shows aren't filtered out.